### PR TITLE
add include statement

### DIFF
--- a/hdp/corpus.h
+++ b/hdp/corpus.h
@@ -2,6 +2,7 @@
 #define	_CORPUS_H
 
 #include <vector>
+#include <cstddef>
 using namespace std;
 
 class document


### PR DESCRIPTION
I added `#include <cstddef>` to corpus.h, which enabled the installation to work.